### PR TITLE
Fix: Using require.True instead of require.Contains

### DIFF
--- a/pkg/diff/compare_test.go
+++ b/pkg/diff/compare_test.go
@@ -126,11 +126,11 @@ func TestCompareFileMultiDocs(t *testing.T) {
 func TestCompareFileNotExist(t *testing.T) {
 	_, err := CompareFile("testdata/left.yaml", "testdata/not-exist.yaml")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "no such file or directory")
+	require.True(t, os.IsNotExist(err), "Expected a file not exist error.")
 
 	_, err = CompareFile("testdata/not-exist.yaml", "testdata/right.yaml")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "no such file or directory")
+	require.True(t, os.IsNotExist(err), "Expected a file not exist error.")
 }
 
 func TestCompareAst(t *testing.T) {


### PR DESCRIPTION
This pull request addresses a platform-specific test failure in the function `TestCompareFileNotExist`.

## Problem

The test previously included this line:

```go
require.Contains(t, err.Error(), "no such file or directory")
```

## Solution

The test now uses os.IsNotExist(err) to check for file-not-found errors in a platform-independent way:

```go
require.True(t, os.IsNotExist(err), "expected a file not exist error")
```

## What’s Covered
- Updated the assertion in TestCompareFileNotExist to use os.IsNotExist

- Ensured test passes on both Windows and UNIX-like systems
