### PR TITLE
Improve website with CodeMirror 6 and UX enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # yamldiff
 
+[![Playground](https://img.shields.io/badge/playground-blue)](https://semihbkgr.github.io/yamldiff)
 [![Go Reference](https://pkg.go.dev/badge/github.com/semihbkgr/yamldiff.svg)](https://pkg.go.dev/github.com/semihbkgr/yamldiff)
 [![Go CI](https://github.com/semihbkgr/yamldiff/actions/workflows/ci.yaml/badge.svg)](https://github.com/semihbkgr/yamldiff/actions/workflows/ci.yaml)
 [![codecov](https://codecov.io/gh/semihbkgr/yamldiff/graph/badge.svg?token=3DYZXV89VE)](https://codecov.io/gh/semihbkgr/yamldiff)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -35,7 +35,7 @@ tasks:
     cmds:
       - GOOS=js GOARCH=wasm go build -o web/yamldiff.wasm ./cmd/wasm
 
-  wasm:exec:
+  wasm:cp-exec:
     desc: Copy wasm_exec.js from Go installation
     cmds:
       - cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" web/
@@ -44,4 +44,4 @@ tasks:
     desc: Build WASM and copy support files
     deps:
       - wasm:build
-      - wasm:exec
+      - wasm:cp-exec

--- a/web/app.js
+++ b/web/app.js
@@ -125,6 +125,7 @@ async function initWasm() {
         );
         go.run(result.instance);
         wasmReady = true;
+        handleCompare();
 
         // Show version
         if (typeof yamldiffVersion === 'function') {

--- a/web/app.js
+++ b/web/app.js
@@ -22,6 +22,26 @@ const editorExtensions = [
         '&': { backgroundColor: 'var(--bg-secondary)' },
         '.cm-gutters': { backgroundColor: 'var(--bg-secondary)', border: 'none' },
     }),
+    EditorView.domEventHandlers({
+        dragover(event) {
+            event.preventDefault();
+            event.currentTarget.closest('.editor-panel').classList.add('drag-over');
+        },
+        dragleave(event) {
+            event.currentTarget.closest('.editor-panel').classList.remove('drag-over');
+        },
+        drop(event, view) {
+            const file = event.dataTransfer.files[0];
+            if (!file) return;
+            event.preventDefault();
+            event.currentTarget.closest('.editor-panel').classList.remove('drag-over');
+            file.text().then(text => {
+                view.dispatch({
+                    changes: { from: 0, to: view.state.doc.length, insert: text },
+                });
+            });
+        },
+    }),
 ];
 
 // Create CodeMirror editors
@@ -48,6 +68,26 @@ metadataCheckbox.addEventListener('change', () => {
     if (metadataCheckbox.checked) {
         pathOnlyCheckbox.checked = false;
     }
+});
+
+// Open file buttons
+document.querySelectorAll('.open-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+        const input = document.createElement('input');
+        input.type = 'file';
+        input.accept = '.yaml,.yml';
+        input.addEventListener('change', () => {
+            const file = input.files[0];
+            if (!file) return;
+            file.text().then(text => {
+                const editor = editors[btn.dataset.target];
+                editor.dispatch({
+                    changes: { from: 0, to: editor.state.doc.length, insert: text },
+                });
+            });
+        });
+        input.click();
+    });
 });
 
 // Clear buttons

--- a/web/app.js
+++ b/web/app.js
@@ -1,211 +1,157 @@
 // yamldiff Web Application
 
-(function() {
-    'use strict';
+import { basicSetup, EditorView } from 'codemirror';
+import { yaml } from '@codemirror/lang-yaml';
+import { oneDark } from '@codemirror/theme-one-dark';
 
-    // DOM elements
-    const leftTextarea = document.getElementById('left');
-    const rightTextarea = document.getElementById('right');
-    const leftHighlight = document.getElementById('leftHighlight');
-    const rightHighlight = document.getElementById('rightHighlight');
-    const leftLineNumbers = document.getElementById('leftLineNumbers');
-    const rightLineNumbers = document.getElementById('rightLineNumbers');
-    const compareBtn = document.getElementById('compare');
-    const outputEl = document.getElementById('output');
-    const statusEl = document.getElementById('status');
-    const versionEl = document.getElementById('version');
-    const ignoreOrderCheckbox = document.getElementById('ignoreOrder');
-    const pathOnlyCheckbox = document.getElementById('pathOnly');
-    const metadataCheckbox = document.getElementById('metadata');
+// DOM elements
+const compareBtn = document.getElementById('compare');
+const outputEl = document.getElementById('output');
+const statusEl = document.getElementById('status');
+const versionEl = document.getElementById('version');
+const ignoreOrderCheckbox = document.getElementById('ignoreOrder');
+const pathOnlyCheckbox = document.getElementById('pathOnly');
+const metadataCheckbox = document.getElementById('metadata');
 
-    // Mutual exclusivity for pathOnly and metadata
-    pathOnlyCheckbox.addEventListener('change', () => {
-        if (pathOnlyCheckbox.checked) {
-            metadataCheckbox.checked = false;
-        }
-    });
+// Shared CodeMirror extensions
+const editorExtensions = [
+    basicSetup,
+    yaml(),
+    oneDark,
+    EditorView.theme({
+        '&': { backgroundColor: 'var(--bg-secondary)' },
+        '.cm-gutters': { backgroundColor: 'var(--bg-secondary)', border: 'none' },
+    }),
+];
 
-    metadataCheckbox.addEventListener('change', () => {
-        if (metadataCheckbox.checked) {
-            pathOnlyCheckbox.checked = false;
-        }
-    });
+// Create CodeMirror editors
+const leftEditor = new EditorView({
+    extensions: editorExtensions,
+    parent: document.getElementById('left-editor'),
+});
 
-    // Debounce helper
-    function debounce(fn, delay) {
-        let timeoutId;
-        return function(...args) {
-            clearTimeout(timeoutId);
-            timeoutId = setTimeout(() => fn.apply(this, args), delay);
-        };
+const rightEditor = new EditorView({
+    extensions: editorExtensions,
+    parent: document.getElementById('right-editor'),
+});
+
+const editors = { left: leftEditor, right: rightEditor };
+
+// Mutual exclusivity for pathOnly and metadata
+pathOnlyCheckbox.addEventListener('change', () => {
+    if (pathOnlyCheckbox.checked) {
+        metadataCheckbox.checked = false;
     }
+});
 
-    // Update line numbers for a textarea
-    function updateLineNumbers(textarea, lineNumbersEl) {
-        const lines = textarea.value.split('\n');
-        const lineCount = lines.length;
-        let html = '';
-        for (let i = 1; i <= lineCount; i++) {
-            html += `<span>${i}</span>`;
-        }
-        lineNumbersEl.innerHTML = html;
+metadataCheckbox.addEventListener('change', () => {
+    if (metadataCheckbox.checked) {
+        pathOnlyCheckbox.checked = false;
     }
+});
 
-    // Update syntax highlighting for a textarea
-    function updateHighlight(textarea, highlightEl) {
-        if (typeof yamldiffColorize === 'function') {
-            const highlighted = yamldiffColorize(textarea.value);
-            highlightEl.innerHTML = highlighted || '';
-        } else {
-            // Fallback: show plain escaped text if WASM not loaded
-            highlightEl.textContent = textarea.value;
-        }
-    }
-
-    // Sync scroll positions
-    function syncScroll(textarea, highlightEl, lineNumbersEl) {
-        const scrollTop = textarea.scrollTop;
-        const scrollLeft = textarea.scrollLeft;
-        // highlightEl is the <code>, its parent <pre> is the scrollable element
-        const preEl = highlightEl.parentElement;
-        preEl.scrollTop = scrollTop;
-        preEl.scrollLeft = scrollLeft;
-        lineNumbersEl.style.transform = `translateY(-${scrollTop}px)`;
-    }
-
-    // Setup highlighting for a textarea
-    function setupEditor(textarea, highlightEl, lineNumbersEl) {
-        const debouncedUpdate = debounce(() => {
-            updateHighlight(textarea, highlightEl);
-            updateLineNumbers(textarea, lineNumbersEl);
-        }, 30);
-
-        textarea.addEventListener('input', debouncedUpdate);
-        textarea.addEventListener('scroll', () => syncScroll(textarea, highlightEl, lineNumbersEl));
-
-        // Initial line numbers
-        updateLineNumbers(textarea, lineNumbersEl);
-    }
-
-    // Initialize editors for both textareas
-    setupEditor(leftTextarea, leftHighlight, leftLineNumbers);
-    setupEditor(rightTextarea, rightHighlight, rightLineNumbers);
-
-    // Clear buttons
-    document.querySelectorAll('.clear-btn').forEach(btn => {
-        btn.addEventListener('click', () => {
-            const target = btn.dataset.target;
-            const textarea = document.getElementById(target);
-            const highlightEl = document.getElementById(target + 'Highlight');
-            const lineNumbersEl = document.getElementById(target + 'LineNumbers');
-            textarea.value = '';
-            if (highlightEl) {
-                highlightEl.innerHTML = '';
-            }
-            if (lineNumbersEl) {
-                lineNumbersEl.innerHTML = '<span>1</span>';
-            }
+// Clear buttons
+document.querySelectorAll('.clear-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+        const editor = editors[btn.dataset.target];
+        editor.dispatch({
+            changes: { from: 0, to: editor.state.doc.length, insert: '' },
         });
     });
+});
 
-    // Initialize WASM
-    async function initWasm() {
-        try {
-            const go = new Go();
-            const result = await WebAssembly.instantiateStreaming(
-                fetch('yamldiff.wasm'),
-                go.importObject
-            );
-            go.run(result.instance);
+// Initialize WASM
+async function initWasm() {
+    try {
+        const go = new Go();
+        const result = await WebAssembly.instantiateStreaming(
+            fetch('yamldiff.wasm'),
+            go.importObject
+        );
+        go.run(result.instance);
 
-            // Enable buttons
-            compareBtn.disabled = false;
-            compareBtn.textContent = 'Compare';
+        // Enable buttons
+        compareBtn.disabled = false;
+        compareBtn.textContent = 'Compare';
 
-            // Show version
-            if (typeof yamldiffVersion === 'function') {
-                const ver = yamldiffVersion();
-                versionEl.textContent = 'Version: ' + (ver || 'dev');
-            }
-
-            // Trigger initial highlighting for default values
-            updateHighlight(leftTextarea, leftHighlight);
-            updateHighlight(rightTextarea, rightHighlight);
-
-            console.log('WASM loaded successfully');
-        } catch (err) {
-            console.error('Failed to load WASM:', err);
-            compareBtn.textContent = 'WASM Error';
-            outputEl.innerHTML = '<span class="error">Failed to load WASM module. Please refresh the page.</span>';
+        // Show version
+        if (typeof yamldiffVersion === 'function') {
+            const ver = yamldiffVersion();
+            versionEl.textContent = 'Version: ' + (ver || 'dev');
         }
+
+        console.log('WASM loaded successfully');
+    } catch (err) {
+        console.error('Failed to load WASM:', err);
+        compareBtn.textContent = 'WASM Error';
+        outputEl.innerHTML = '<span class="error">Failed to load WASM module. Please refresh the page.</span>';
+    }
+}
+
+// Format diff output - WASM now returns HTML-formatted output
+function formatDiffOutput(html) {
+    if (!html || html.trim() === '') {
+        return '<span class="no-diff">No differences found</span>';
+    }
+    // WASM output is already HTML-formatted and escaped
+    return html;
+}
+
+// Compare handler
+function handleCompare() {
+    const left = leftEditor.state.doc.toString();
+    const right = rightEditor.state.doc.toString();
+
+    if (!left && !right) {
+        outputEl.innerHTML = '<span class="no-diff">Enter YAML content in both panels to compare</span>';
+        statusEl.textContent = '';
+        return;
     }
 
-    // Format diff output - WASM now returns HTML-formatted output
-    function formatDiffOutput(html) {
-        if (!html || html.trim() === '') {
-            return '<span class="no-diff">No differences found</span>';
+    const options = {
+        ignoreOrder: ignoreOrderCheckbox.checked,
+        pathOnly: pathOnlyCheckbox.checked,
+        metadata: metadataCheckbox.checked
+    };
+
+    try {
+        const result = yamldiffCompare(left, right, options);
+
+        if (result.error) {
+            outputEl.innerHTML = `<span class="error">Error: ${escapeHtml(result.error)}</span>`;
+            statusEl.textContent = 'Parse error';
+        } else {
+            outputEl.innerHTML = formatDiffOutput(result.result);
+            statusEl.textContent = result.hasDiff ? 'Differences found' : 'No differences';
         }
-        // WASM output is already HTML-formatted and escaped
-        return html;
+    } catch (err) {
+        outputEl.innerHTML = `<span class="error">Error: ${escapeHtml(err.message)}</span>`;
+        statusEl.textContent = 'Error';
     }
+}
 
-    // Compare handler
-    function handleCompare() {
-        const left = leftTextarea.value;
-        const right = rightTextarea.value;
+// Escape HTML helper
+function escapeHtml(text) {
+    return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
 
-        if (!left && !right) {
-            outputEl.innerHTML = '<span class="no-diff">Enter YAML content in both panels to compare</span>';
-            statusEl.textContent = '';
-            return;
-        }
+// Event listeners
+compareBtn.addEventListener('click', handleCompare);
 
-        const options = {
-            ignoreOrder: ignoreOrderCheckbox.checked,
-            pathOnly: pathOnlyCheckbox.checked,
-            metadata: metadataCheckbox.checked
-        };
-
-        try {
-            const result = yamldiffCompare(left, right, options);
-
-            if (result.error) {
-                outputEl.innerHTML = `<span class="error">Error: ${escapeHtml(result.error)}</span>`;
-                statusEl.textContent = 'Parse error';
-            } else {
-                outputEl.innerHTML = formatDiffOutput(result.result);
-                statusEl.textContent = result.hasDiff ? 'Differences found' : 'No differences';
-            }
-        } catch (err) {
-            outputEl.innerHTML = `<span class="error">Error: ${escapeHtml(err.message)}</span>`;
-            statusEl.textContent = 'Error';
+// Keyboard shortcut: Ctrl/Cmd + Enter to compare
+document.addEventListener('keydown', (e) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+        e.preventDefault();
+        if (!compareBtn.disabled) {
+            handleCompare();
         }
     }
+});
 
-
-    // Escape HTML helper
-    function escapeHtml(text) {
-        return text
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#039;');
-    }
-
-    // Event listeners
-    compareBtn.addEventListener('click', handleCompare);
-
-    // Keyboard shortcut: Ctrl/Cmd + Enter to compare
-    document.addEventListener('keydown', (e) => {
-        if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
-            e.preventDefault();
-            if (!compareBtn.disabled) {
-                handleCompare();
-            }
-        }
-    });
-
-    // Initialize
-    initWasm();
-})();
+// Initialize
+initWasm();

--- a/web/index.html
+++ b/web/index.html
@@ -36,15 +36,21 @@
         <div class="editor-container">
             <div class="editor-panel">
                 <div class="panel-header">
-                    <span>Left YAML</span>
-                    <button type="button" class="clear-btn" data-target="left">Clear</button>
+                    <span>Old YAML</span>
+                    <div class="panel-actions">
+                        <button type="button" class="open-btn" data-target="left">Open</button>
+                        <button type="button" class="clear-btn" data-target="left">Clear</button>
+                    </div>
                 </div>
                 <div id="left-editor"></div>
             </div>
             <div class="editor-panel">
                 <div class="panel-header">
-                    <span>Right YAML</span>
-                    <button type="button" class="clear-btn" data-target="right">Clear</button>
+                    <span>New YAML</span>
+                    <div class="panel-actions">
+                        <button type="button" class="open-btn" data-target="right">Open</button>
+                        <button type="button" class="clear-btn" data-target="right">Clear</button>
+                    </div>
                 </div>
                 <div id="right-editor"></div>
             </div>

--- a/web/index.html
+++ b/web/index.html
@@ -5,6 +5,21 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>yamldiff - YAML Diff Tool</title>
     <link rel="stylesheet" href="style.css">
+    <script type="importmap">
+    {
+        "imports": {
+            "codemirror": "https://esm.sh/*codemirror@6.0.2",
+            "@codemirror/lang-yaml": "https://esm.sh/*@codemirror/lang-yaml@6.1.2",
+            "@codemirror/theme-one-dark": "https://esm.sh/*@codemirror/theme-one-dark@6.1.3",
+            "@codemirror/": "https://esm.sh/*@codemirror/",
+            "@lezer/": "https://esm.sh/*@lezer/",
+            "style-mod": "https://esm.sh/style-mod",
+            "w3c-keyname": "https://esm.sh/w3c-keyname",
+            "crelt": "https://esm.sh/crelt",
+            "@marijn/find-cluster-break": "https://esm.sh/@marijn/find-cluster-break"
+        }
+    }
+    </script>
 </head>
 <body>
     <header>
@@ -24,30 +39,14 @@
                     <span>Left YAML</span>
                     <button type="button" class="clear-btn" data-target="left">Clear</button>
                 </div>
-                <div class="editor-wrapper">
-                    <div class="line-numbers">
-                        <div class="line-numbers-inner" id="leftLineNumbers"></div>
-                    </div>
-                    <div class="editor-content">
-                        <pre class="editor-highlight"><code id="leftHighlight"></code></pre>
-                        <textarea id="left" placeholder="Paste your left YAML here..." spellcheck="false"></textarea>
-                    </div>
-                </div>
+                <div id="left-editor"></div>
             </div>
             <div class="editor-panel">
                 <div class="panel-header">
                     <span>Right YAML</span>
                     <button type="button" class="clear-btn" data-target="right">Clear</button>
                 </div>
-                <div class="editor-wrapper">
-                    <div class="line-numbers">
-                        <div class="line-numbers-inner" id="rightLineNumbers"></div>
-                    </div>
-                    <div class="editor-content">
-                        <pre class="editor-highlight"><code id="rightHighlight"></code></pre>
-                        <textarea id="right" placeholder="Paste your right YAML here..." spellcheck="false"></textarea>
-                    </div>
-                </div>
+                <div id="right-editor"></div>
             </div>
         </div>
 
@@ -89,6 +88,6 @@
     </footer>
 
     <script src="wasm_exec.js"></script>
-    <script src="app.js"></script>
+    <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -4,6 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>yamldiff - YAML Diff Tool</title>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-X7REVJ5Z2E"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-X7REVJ5Z2E');
+    </script>
     <link rel="stylesheet" href="style.css">
     <script type="importmap">
     {

--- a/web/index.html
+++ b/web/index.html
@@ -56,30 +56,13 @@
             </div>
         </div>
 
-        <div class="controls">
-            <div class="options">
-                <label>
-                    <input type="checkbox" id="ignoreOrder">
-                    <span>Ignore sequence order</span>
-                </label>
-                <label>
-                    <input type="checkbox" id="pathOnly">
-                    <span>Paths only</span>
-                </label>
-                <label>
-                    <input type="checkbox" id="metadata">
-                    <span>Show metadata</span>
-                </label>
-            </div>
-            <div class="buttons">
-                <button type="button" id="compare" disabled>Loading WASM...</button>
-            </div>
-        </div>
-
         <div class="output-container">
             <div class="panel-header">
                 <span>Diff Output</span>
-                <span id="status"></span>
+                <label class="option-label">
+                    <input type="checkbox" id="ignoreOrder">
+                    <span>Ignore sequence order</span>
+                </label>
             </div>
             <pre id="output"></pre>
         </div>

--- a/web/style.css
+++ b/web/style.css
@@ -91,10 +91,20 @@ main {
     min-height: 0;
 }
 
+.editor-panel .cm-editor {
+    transition: filter 0.2s;
+}
+
 .editor-panel.drag-over {
     border-color: var(--accent-hover);
+    background-color: rgba(17, 119, 187, 0.08);
     box-shadow: inset 0 0 30px rgba(17, 119, 187, 0.15), 0 0 8px rgba(17, 119, 187, 0.3);
-    transition: border-color 0.2s, box-shadow 0.2s;
+    transition: border-color 0.2s, box-shadow 0.2s, background-color 0.2s;
+}
+
+.editor-panel.drag-over .cm-editor {
+    filter: blur(1.5px);
+    pointer-events: none;
 }
 
 .panel-header {

--- a/web/style.css
+++ b/web/style.css
@@ -118,88 +118,25 @@ main {
     color: var(--text-primary);
 }
 
-.editor-wrapper {
+#left-editor,
+#right-editor {
     flex: 1;
-    display: flex;
-    min-height: 0;
-    overflow: hidden;
-}
-
-.line-numbers {
-    flex-shrink: 0;
-    width: 3rem;
-    padding: 0.75rem 0.5rem;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    line-height: 1.5;
-    text-align: right;
-    color: var(--text-secondary);
-    background-color: var(--bg-tertiary);
-    border-right: 1px solid var(--border-color);
-    overflow: hidden;
-    user-select: none;
-}
-
-.line-numbers-inner {
     display: flex;
     flex-direction: column;
-}
-
-.line-numbers-inner span {
-    display: block;
-}
-
-.editor-content {
-    flex: 1;
     min-height: 0;
-    position: relative;
 }
 
-.editor-highlight {
-    position: absolute;
-    inset: 0;
-    margin: 0;
-    padding: 0.75rem;
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    line-height: 1.5;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    overflow: hidden;
-    pointer-events: none;
-    color: var(--text-primary);
-    background-color: var(--bg-secondary);
-}
-
-.editor-highlight code {
-    font-family: inherit;
-    font-size: inherit;
-    line-height: inherit;
-}
-
-textarea {
-    display: block;
-    position: absolute;
-    inset: 0;
-    resize: none;
-    border: none;
-    background-color: transparent;
-    color: transparent;
-    caret-color: var(--text-primary);
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    padding: 0.75rem;
-    line-height: 1.5;
-    z-index: 1;
+.cm-editor {
+    flex: 1;
     overflow: auto;
 }
 
-textarea:focus {
+.cm-editor.cm-focused {
     outline: none;
 }
 
-textarea::placeholder {
-    color: var(--text-secondary);
+.cm-editor .cm-scroller {
+    scrollbar-color: var(--border-color) transparent;
 }
 
 .controls {

--- a/web/style.css
+++ b/web/style.css
@@ -91,6 +91,12 @@ main {
     min-height: 0;
 }
 
+.editor-panel.drag-over {
+    border-color: var(--accent-hover);
+    box-shadow: inset 0 0 30px rgba(17, 119, 187, 0.15), 0 0 8px rgba(17, 119, 187, 0.3);
+    transition: border-color 0.2s, box-shadow 0.2s;
+}
+
 .panel-header {
     display: flex;
     justify-content: space-between;
@@ -102,6 +108,12 @@ main {
     font-weight: 500;
 }
 
+.panel-actions {
+    display: flex;
+    gap: 0.25rem;
+}
+
+.open-btn,
 .clear-btn {
     background: transparent;
     border: 1px solid var(--border-color);
@@ -113,6 +125,7 @@ main {
     transition: all 0.2s;
 }
 
+.open-btn:hover,
 .clear-btn:hover {
     background-color: var(--bg-primary);
     color: var(--text-primary);

--- a/web/style.css
+++ b/web/style.css
@@ -162,40 +162,21 @@ main {
     scrollbar-color: var(--border-color) transparent;
 }
 
-.controls {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 1rem;
-    padding: 0.75rem 1rem;
-    background-color: var(--bg-secondary);
-    border: 1px solid var(--border-color);
-    border-radius: 6px;
-}
-
-.options {
-    display: flex;
-    gap: 1.5rem;
-}
-
-.options label {
+.option-label {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4rem;
     cursor: pointer;
-    font-size: 0.85rem;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
 }
 
-.options input[type="checkbox"] {
-    width: 1rem;
-    height: 1rem;
+.option-label input[type="checkbox"] {
+    width: 0.85rem;
+    height: 0.85rem;
     cursor: pointer;
 }
 
-.buttons {
-    display: flex;
-    gap: 0.5rem;
-}
 
 button {
     background-color: var(--accent-color);
@@ -238,11 +219,6 @@ button:disabled {
     line-height: 1.6;
     white-space: pre-wrap;
     word-wrap: break-word;
-}
-
-#status {
-    font-size: 0.8rem;
-    color: var(--text-secondary);
 }
 
 .diff-added {
@@ -324,20 +300,6 @@ footer a:hover {
 @media (max-width: 768px) {
     .editor-container {
         grid-template-columns: 1fr;
-    }
-
-    .controls {
-        flex-direction: column;
-        align-items: stretch;
-    }
-
-    .options {
-        flex-wrap: wrap;
-        justify-content: center;
-    }
-
-    .buttons {
-        justify-content: center;
     }
 
     main {


### PR DESCRIPTION
## Summary
- Replace textarea editors with CodeMirror 6 for YAML syntax highlighting, line numbers, and dark theme
- Load CodeMirror from esm.sh CDN using importmap with `*` prefix for dependency deduplication
- Add file open button and drag-and-drop support with blur effect and glow feedback
- Rename editor panels from "Left/Right YAML" to "Old/New YAML"
- Replace manual Compare button with automatic diffing on editor changes (300ms debounce)
- Move ignore-sequence-order option into the Diff Output panel header and remove unused options

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to a significant rewrite of the web playground’s editor/diff interaction and new third-party CDN module loading; core diffing still delegates to the existing WASM API.
> 
> **Overview**
> Upgrades the web playground UI to replace the custom textarea + manual highlighting implementation with CodeMirror 6 (YAML mode + One Dark theme) loaded via an `importmap`, and switches `app.js` to an ES module.
> 
> Changes comparison behavior to *auto-run diffing* on editor edits (300ms debounce) and when `ignoreOrder` toggles, removing the explicit Compare button and the `pathOnly`/`metadata` options from the UI.
> 
> Adds usability improvements including per-panel **Open** buttons, drag-and-drop file loading with visual feedback (glow/blur), renames panels to **Old/New YAML**, adds Google Analytics to `index.html`, and renames the Taskfile step to `wasm:cp-exec`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 658eea69db73c1edd5bca02ad7a76c0894d03f7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->